### PR TITLE
Add prospekt selection for Lidl scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # Project_Groceries
-My personal project, where I want to write a groceries scraper using python and then train a model to identify different sales on this week
+My personal project, where I want to write a groceries scraper using python and then train a model to identify different sales on this week.
+
+## Usage
+
+To scrape Lidl flyers and choose which prospect to download, use the `--prospekt-index` argument (1 = first flyer):
+
+```
+python scraper.py --site lidl --prospekt-index 2
+```
+
+This downloads the second available flyer instead of the default first one.


### PR DESCRIPTION
## Summary
- allow scrapers to expose prospekt names and pick one by index
- add `--prospekt-index` CLI flag and document its use
- update Lidl scraper to support selecting among multiple flyers

## Testing
- `python -m py_compile scraper.py`
- `python scraper.py --help` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a463d314c483239261544bf595baa8